### PR TITLE
feat: registry-driven chain config

### DIFF
--- a/packages/exit-app/package.json
+++ b/packages/exit-app/package.json
@@ -8,6 +8,7 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
+    "test:chains": "node --test src/chains/*.nodetest.ts",
     "build:types": "typechain --target ethers-v5 --out-dir ./src/contracts/types ./src/contracts/abis/*.json",
     "postinstall": "yarn build:types"
   },

--- a/packages/exit-app/src/chains/deriveChain.nodetest.ts
+++ b/packages/exit-app/src/chains/deriveChain.nodetest.ts
@@ -1,0 +1,131 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  deriveExplorerApiUrl,
+  deriveExplorerUrl,
+  deriveExplorerName,
+  deriveRpc,
+  deriveSafeUrl,
+  deriveVerifyContractUrl,
+  normalizeTransactionService,
+  toAppChain,
+} from './deriveChain.ts'
+import type { RegistryChainRaw } from './deriveChain.ts'
+
+const rawMainnet: RegistryChainRaw = {
+  chainId: '1',
+  chainName: 'Ethereum',
+  shortName: 'eth',
+  nativeCurrency: { symbol: 'ETH', decimals: 18 },
+  safeAppsRpcUri: { value: 'https://mainnet.infura.io/v3/{{INFURA_API_KEY}}' },
+  blockExplorerUriTemplate: {
+    address: 'https://etherscan.io/address/{{address}}',
+    api: 'https://api.etherscan.io/v2/api?module={{module}}&action={{action}}',
+  },
+  transactionService: 'https://transaction-mainnet.safe.protofire.io',
+  features: ['ZODIAC'],
+}
+
+test('deriveExplorerApiUrl truncates the registry api template at the query string', () => {
+  // Registry serves a full Etherscan-V2 template; the app builds its own query params,
+  // so everything from `?` onward must be dropped.
+  assert.equal(
+    deriveExplorerApiUrl('https://api.etherscan.io/v2/api?module={{module}}&action={{action}}'),
+    'https://api.etherscan.io/v2/api',
+  )
+})
+
+test('deriveExplorerUrl strips the /address/{{address}} tail and trailing slash', () => {
+  assert.equal(
+    deriveExplorerUrl('https://etherscan.io/address/{{address}}'),
+    'https://etherscan.io',
+  )
+  // already a bare origin
+  assert.equal(deriveExplorerUrl('https://gnosisscan.io/'), 'https://gnosisscan.io')
+  // a path that is not the address template is preserved (no over-trimming)
+  assert.equal(
+    deriveExplorerUrl('https://unichain.blockscout.com/address/{{address}}'),
+    'https://unichain.blockscout.com',
+  )
+})
+
+test('deriveExplorerName takes the host, strips www., and title-cases', () => {
+  assert.equal(deriveExplorerName('https://etherscan.io/address/{{address}}'), 'Etherscan')
+  assert.equal(deriveExplorerName('https://www.snowtrace.io/address/{{address}}'), 'Snowtrace')
+  assert.equal(
+    deriveExplorerName('https://unichain.blockscout.com/address/{{address}}'),
+    'Unichain',
+  )
+})
+
+test('deriveRpc prefers safeApps > public > rpc but skips templated-key URIs when a usable one exists', () => {
+  // safeApps is an Infura template (unusable once the key is stripped) and a public RPC
+  // exists -> prefer the usable public RPC rather than a keyless Infura URL.
+  assert.equal(
+    deriveRpc({
+      safeAppsRpcUri: { value: 'https://mainnet.infura.io/v3/{{INFURA_API_KEY}}' },
+      publicRpcUri: { value: 'https://cloudflare-eth.com' },
+    }),
+    'https://cloudflare-eth.com',
+  )
+  // a non-templated safeApps URI keeps top priority
+  assert.equal(
+    deriveRpc({
+      safeAppsRpcUri: { value: 'https://safe-rpc.protofire.io/eth' },
+      publicRpcUri: { value: 'https://cloudflare-eth.com' },
+    }),
+    'https://safe-rpc.protofire.io/eth',
+  )
+  // all candidates templated -> strip the first (best-effort, key dropped)
+  assert.equal(
+    deriveRpc({ safeAppsRpcUri: { value: 'https://x.infura.io/v3/{{INFURA_API_KEY}}' } }),
+    'https://x.infura.io/v3',
+  )
+  // falls through to publicRpcUri then rpcUri
+  assert.equal(deriveRpc({ publicRpcUri: { value: 'https://rpc.ankr.com/eth' } }), 'https://rpc.ankr.com/eth')
+  assert.equal(deriveRpc({ rpcUri: { value: 'https://x.io' } }), 'https://x.io')
+  // nothing available
+  assert.equal(deriveRpc({}), '')
+})
+
+test('deriveSafeUrl is parentOrigin + shortName with a trailing colon', () => {
+  assert.equal(deriveSafeUrl('https://app.safe.protofire.io', 'eth'), 'https://app.safe.protofire.io/eth:')
+  // parent origin with trailing slash is normalised
+  assert.equal(deriveSafeUrl('https://safe.linea.build/', 'linea'), 'https://safe.linea.build/linea:')
+})
+
+test('deriveVerifyContractUrl appends /verifyContract to the explorer base', () => {
+  assert.equal(deriveVerifyContractUrl('https://etherscan.io'), 'https://etherscan.io/verifyContract')
+})
+
+test('normalizeTransactionService enforces a single trailing slash, passes null through', () => {
+  assert.equal(normalizeTransactionService('https://tx.safe.protofire.io'), 'https://tx.safe.protofire.io/')
+  assert.equal(normalizeTransactionService('https://tx.safe.protofire.io/'), 'https://tx.safe.protofire.io/')
+  // a FALLBACK chain with no tx-service disables the feature rather than guessing a host
+  assert.equal(normalizeTransactionService(null), null)
+  assert.equal(normalizeTransactionService(undefined), null)
+})
+
+test('toAppChain maps a raw registry entry onto the full app chain shape', () => {
+  const chain = toAppChain(rawMainnet, { parentOrigin: 'https://app.safe.protofire.io' })
+  assert.deepEqual(chain, {
+    chainId: 1,
+    name: 'Ethereum',
+    shortName: 'eth',
+    nativeAsset: { symbol: 'ETH', decimals: 18 },
+    rpc: 'https://mainnet.infura.io/v3',
+    explorer: {
+      name: 'Etherscan',
+      url: 'https://etherscan.io',
+      apiUrl: 'https://api.etherscan.io/v2/api',
+    },
+    verifyContractUrl: 'https://etherscan.io/verifyContract',
+    safeTransactionApi: 'https://transaction-mainnet.safe.protofire.io/',
+    safeUrl: 'https://app.safe.protofire.io/eth:',
+    features: ['ZODIAC'],
+  })
+})
+
+test('toAppChain returns null for a non-numeric chainId', () => {
+  assert.equal(toAppChain({ ...rawMainnet, chainId: 'not-a-number' }, { parentOrigin: 'x' }), null)
+})

--- a/packages/exit-app/src/chains/deriveChain.ts
+++ b/packages/exit-app/src/chains/deriveChain.ts
@@ -1,0 +1,150 @@
+// Pure derivation layer: maps a raw Chain Registry entry onto the app's chain shape.
+// No app imports, no `import.meta.env`, no browser globals — every input is a parameter,
+// so this module is unit-testable in isolation (see deriveChain.nodetest.ts).
+
+/** The subset of a Chain Registry `/api/v1/chains/` entry the apps consume. */
+export interface RegistryChainRaw {
+  chainId: string
+  chainName: string
+  shortName: string
+  nativeCurrency: { symbol: string; decimals: number; name?: string }
+  safeAppsRpcUri?: { value?: string }
+  publicRpcUri?: { value?: string }
+  rpcUri?: { value?: string }
+  blockExplorerUriTemplate: { address: string; api: string; txHash?: string }
+  transactionService?: string | null
+  features?: string[]
+}
+
+/** The normalised chain metadata the app reads everywhere (registry- or FALLBACK-sourced). */
+export interface AppChain {
+  chainId: number
+  name: string
+  shortName: string
+  nativeAsset: { symbol: string; decimals: number }
+  rpc: string
+  explorer: { name: string; url: string; apiUrl: string }
+  verifyContractUrl: string
+  safeTransactionApi: string | null
+  safeUrl: string
+  features: string[]
+}
+
+/**
+ * The explorer `api` base, with the query template truncated.
+ * The registry serves a full Etherscan-V2 template
+ * (`https://api.etherscan.io/v2/api?module={{module}}&...`); the app builds its own
+ * `module/action/address/chainid/apiKey` query via URLSearchParams, so we keep the
+ * base only. Truncating at `?` also sidesteps the malformed `&` in the registry's
+ * Base (8453) template.
+ */
+export const deriveExplorerApiUrl = (apiTemplate: string): string =>
+  apiTemplate.split('?')[0]
+
+/**
+ * The explorer browse base: the registry `address` template with the
+ * `/address/{{address}}` tail and any trailing slash removed.
+ */
+export const deriveExplorerUrl = (addressTemplate: string): string =>
+  addressTemplate.replace(/\/address\/\{\{address\}\}\/?$/, '').replace(/\/+$/, '')
+
+/**
+ * A display label for the explorer, derived from the host of the `address` template:
+ * drop `www.`, take the first DNS label, title-case it (e.g. `etherscan` -> `Etherscan`).
+ * Best-effort — the registry carries no explorer display name.
+ */
+export const deriveExplorerName = (addressTemplate: string): string => {
+  let host: string
+  try {
+    host = new URL(addressTemplate).hostname
+  } catch {
+    host = addressTemplate
+  }
+  const label = host.replace(/^www\./, '').split('.')[0]
+  return label.charAt(0).toUpperCase() + label.slice(1)
+}
+
+interface RpcUri {
+  value?: string
+}
+
+/**
+ * Read RPC endpoint, preferring `safeAppsRpcUri` -> `publicRpcUri` -> `rpcUri`.
+ * Any `{{...}}` template token (e.g. an Infura key placeholder) and the resulting
+ * trailing slash are dropped — the embedded app prefers its injected provider and the
+ * committed Infura key is removed.
+ */
+export const deriveRpc = (uris: {
+  safeAppsRpcUri?: RpcUri
+  publicRpcUri?: RpcUri
+  rpcUri?: RpcUri
+}): string => {
+  const candidates = [
+    uris.safeAppsRpcUri?.value,
+    uris.publicRpcUri?.value,
+    uris.rpcUri?.value,
+  ].filter((v): v is string => !!v)
+  if (candidates.length === 0) return ''
+  const isTemplated = (v: string) => /\{\{[^}]+\}\}/.test(v)
+  // Prefer (in priority order) a URI with no template token, since stripping a key
+  // placeholder leaves an unusable endpoint; fall back to the first if all are templated.
+  const chosen = candidates.find((v) => !isTemplated(v)) ?? candidates[0]
+  return chosen
+    .replace(/\/?\{\{[^}]+\}\}/g, '') // drop `/{{INFURA_API_KEY}}` style segments
+    .replace(/\/+$/, '')
+}
+
+/**
+ * The embedding Safe UI link base: the parent frame origin + the registry `shortName`,
+ * e.g. `https://app.safe.protofire.io/eth:`. Built only for the embedding chain.
+ */
+export const deriveSafeUrl = (parentOrigin: string, shortName: string): string =>
+  `${parentOrigin.replace(/\/+$/, '')}/${shortName}:`
+
+/** The explorer's contract-verification page. */
+export const deriveVerifyContractUrl = (explorerUrl: string): string =>
+  `${explorerUrl}/verifyContract`
+
+/**
+ * The Safe Transaction Service base, normalised to exactly one trailing slash.
+ * `null`/`undefined` (only possible for a FALLBACK chain that lacks one) passes through
+ * as `null`, disabling tx-service reads rather than defaulting to a wrong host.
+ */
+export const normalizeTransactionService = (
+  transactionService: string | null | undefined,
+): string | null => {
+  if (!transactionService) return null
+  return transactionService.replace(/\/+$/, '') + '/'
+}
+
+/**
+ * Map a raw registry entry onto the normalised {@link AppChain}.
+ * `parentOrigin` is the embedding Safe UI's origin, used to derive `safeUrl`.
+ * Returns `null` when `chainId` is not a parseable number (the entry is skipped).
+ */
+export const toAppChain = (
+  raw: RegistryChainRaw,
+  { parentOrigin }: { parentOrigin: string },
+): AppChain | null => {
+  const chainId = parseInt(raw.chainId, 10)
+  if (Number.isNaN(chainId)) return null
+
+  const explorerUrl = deriveExplorerUrl(raw.blockExplorerUriTemplate.address)
+
+  return {
+    chainId,
+    name: raw.chainName,
+    shortName: raw.shortName,
+    nativeAsset: { symbol: raw.nativeCurrency.symbol, decimals: raw.nativeCurrency.decimals },
+    rpc: deriveRpc(raw),
+    explorer: {
+      name: deriveExplorerName(raw.blockExplorerUriTemplate.address),
+      url: explorerUrl,
+      apiUrl: deriveExplorerApiUrl(raw.blockExplorerUriTemplate.api),
+    },
+    verifyContractUrl: deriveVerifyContractUrl(explorerUrl),
+    safeTransactionApi: normalizeTransactionService(raw.transactionService),
+    safeUrl: deriveSafeUrl(parentOrigin, raw.shortName),
+    features: raw.features ?? [],
+  }
+}

--- a/packages/exit-app/src/chains/fallback.ts
+++ b/packages/exit-app/src/chains/fallback.ts
@@ -1,0 +1,70 @@
+import type { AppChain } from './deriveChain.ts'
+import { deriveSafeUrl, deriveVerifyContractUrl } from './deriveChain.ts'
+
+// Manual exceptions only — chains the Chain Registry does not (yet) carry. The registry
+// always wins (`registry[id] ?? cache[id] ?? FALLBACK[id]`); an entry here is deleted
+// once the registry serves that chain. This is NOT a snapshot of all chains.
+//
+// `safeTransactionApi` is intentionally `null`: these chains' former tx-service hosts
+// were on `safe.global`, which has been dropped. A FALLBACK chain with no tx-service
+// disables tx-service reads rather than guessing a host (until it lands in the registry).
+// `safeUrl` is built from the embedding parent origin at runtime, like registry chains.
+
+interface FallbackSeed {
+  chainId: number
+  name: string
+  shortName: string
+  nativeAsset: { symbol: string; decimals: number }
+  explorer: { name: string; url: string; apiUrl: string }
+}
+
+const SEEDS: FallbackSeed[] = [
+  {
+    chainId: 43111,
+    name: 'hemi',
+    shortName: 'hemi',
+    nativeAsset: { symbol: 'ETH', decimals: 18 },
+    explorer: { name: 'Hemi Explorer', url: 'https://explorer.hemi.network', apiUrl: 'https://api.hemi.network/api' },
+  },
+  {
+    chainId: 747474,
+    name: 'katana',
+    shortName: 'katana',
+    nativeAsset: { symbol: 'ETH', decimals: 18 },
+    explorer: { name: 'Katana Explorer', url: 'https://explorer.katana.network', apiUrl: 'https://api.katana.network/api' },
+  },
+  {
+    chainId: 232,
+    name: 'lens',
+    shortName: 'lens',
+    nativeAsset: { symbol: 'GHO', decimals: 18 },
+    explorer: { name: 'Lens Explorer', url: 'https://explorer.lens.xyz', apiUrl: 'https://api.lens.xyz/api' },
+  },
+  {
+    chainId: 3338,
+    name: 'peaq',
+    shortName: 'PEAQ',
+    nativeAsset: { symbol: 'PEAQ', decimals: 18 },
+    explorer: { name: 'Peaq Explorer', url: 'https://explorer.peaq.network', apiUrl: 'https://api.peaq.network/api' },
+  },
+]
+
+/** Build the FALLBACK map, deriving `safeUrl` from the embedding parent origin. */
+export const buildFallback = (parentOrigin: string): Record<number, AppChain> => {
+  const map: Record<number, AppChain> = {}
+  for (const seed of SEEDS) {
+    map[seed.chainId] = {
+      chainId: seed.chainId,
+      name: seed.name,
+      shortName: seed.shortName,
+      nativeAsset: seed.nativeAsset,
+      rpc: '', // embedded app prefers its injected provider
+      explorer: seed.explorer,
+      verifyContractUrl: deriveVerifyContractUrl(seed.explorer.url),
+      safeTransactionApi: null,
+      safeUrl: deriveSafeUrl(parentOrigin, seed.shortName),
+      features: [],
+    }
+  }
+  return map
+}

--- a/packages/exit-app/src/chains/registry.ts
+++ b/packages/exit-app/src/chains/registry.ts
@@ -1,0 +1,51 @@
+// Browser-wired singleton over the testable registry store. This is the module the app
+// imports; it supplies the real fetch/localStorage/clock and derives the embedding parent
+// origin for safeUrl.
+//
+// CRA app: env is read via process.env.REACT_APP_* (NOT import.meta.env).
+// No app-side gate: every chain the registry carries is offered. If the network exists in
+// the registry, it works.
+import { createRegistryStore } from './registryStore'
+import { buildFallback } from './fallback'
+import type { AppChain } from './deriveChain'
+
+export const REGISTRY_URL =
+  process.env.REACT_APP_CHAIN_REGISTRY_URL || 'https://registry.safe.protofire.io/api/v1/chains/'
+const STORAGE_KEY = 'zodiac.chainRegistry'
+const TIMEOUT_MS = 2500 // exit divergence
+const TTL_MS = 7 * 24 * 60 * 60 * 1000 // 7d
+
+/**
+ * The embedding Safe UI's origin. The app is iframed inside the Safe UI that owns the
+ * chain, so the parent frame origin is the correct base for safeUrl.
+ */
+const getParentOrigin = (): string => {
+  try {
+    const ancestors = window.location.ancestorOrigins
+    if (ancestors && ancestors.length > 0) return ancestors[0]
+    if (document.referrer) return new URL(document.referrer).origin
+  } catch {
+    /* fall through to own origin */
+  }
+  return window.location.origin
+}
+
+const parentOrigin = getParentOrigin()
+
+const store = createRegistryStore({
+  fetchFn: (...args) => fetch(...args),
+  storage: typeof localStorage !== 'undefined' ? localStorage : undefined,
+  now: () => Date.now(),
+  parentOrigin,
+  registryUrl: REGISTRY_URL,
+  timeoutMs: TIMEOUT_MS,
+  ttlMs: TTL_MS,
+  fallback: buildFallback(parentOrigin),
+  // No gate: any chain present in the registry (or FALLBACK) is offered.
+  storageKey: STORAGE_KEY,
+})
+
+export const initRegistry = (): Promise<void> => store.init()
+export const getRegistryChain = (chainId: number): AppChain | undefined => store.getChain(chainId)
+export const getAllRegistryChains = (): AppChain[] => store.getAllChains()
+export const getRegistrySource = () => store.getSource()

--- a/packages/exit-app/src/chains/registryStore.nodetest.ts
+++ b/packages/exit-app/src/chains/registryStore.nodetest.ts
@@ -1,0 +1,137 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { createRegistryStore } from './registryStore.ts'
+import type { RegistryChainRaw } from './deriveChain.ts'
+import type { AppChain } from './deriveChain.ts'
+
+const raw = (chainId: string, shortName: string, extra: Partial<RegistryChainRaw> = {}): RegistryChainRaw => ({
+  chainId,
+  chainName: `Chain ${chainId}`,
+  shortName,
+  nativeCurrency: { symbol: 'ETH', decimals: 18 },
+  publicRpcUri: { value: `https://rpc.${shortName}.example` },
+  blockExplorerUriTemplate: {
+    address: `https://${shortName}.example/address/{{address}}`,
+    api: `https://api.${shortName}.example/api?x=1`,
+  },
+  transactionService: `https://tx.${shortName}.example`,
+  ...extra,
+})
+
+// A fetch fake that serves the given pages in order; `next` chains them.
+const pagedFetch = (pages: RegistryChainRaw[][]) => {
+  const urls = pages.map((_, i) => `https://reg/page/${i}`)
+  return async (url: string | URL) => {
+    const u = String(url)
+    const idx = u.includes('/page/') ? Number(u.split('/page/')[1]) : 0
+    const results = pages[idx] ?? []
+    const next = idx + 1 < pages.length ? urls[idx + 1] : null
+    return { ok: true, json: async () => ({ results, next }) } as unknown as Response
+  }
+}
+
+const memStorage = (): Storage => {
+  const m = new Map<string, string>()
+  return {
+    getItem: (k) => m.get(k) ?? null,
+    setItem: (k, v) => void m.set(k, String(v)),
+    removeItem: (k) => void m.delete(k),
+    clear: () => m.clear(),
+    key: (i) => Array.from(m.keys())[i] ?? null,
+    get length() {
+      return m.size
+    },
+  } as Storage
+}
+
+const baseDeps = () => ({
+  fetchFn: pagedFetch([[raw('1', 'eth')]]),
+  storage: memStorage(),
+  now: () => 1000,
+  parentOrigin: 'https://app.safe.protofire.io',
+  registryUrl: 'https://reg/page/0',
+  timeoutMs: 100,
+  ttlMs: 10_000,
+  fallback: {} as Record<number, AppChain>,
+})
+
+test('init follows `next` across pages and exposes every chain', async () => {
+  const store = createRegistryStore({
+    ...baseDeps(),
+    fetchFn: pagedFetch([[raw('1', 'eth')], [raw('100', 'gno')], [raw('10', 'oeth')]]),
+  })
+  await store.init()
+  assert.equal(store.getSource(), 'registry')
+  assert.deepEqual(
+    store.getAllChains().map((c) => c.chainId).sort((a, b) => a - b),
+    [1, 10, 100],
+  )
+})
+
+test('init dedupes repeated chainIds (first occurrence wins)', async () => {
+  const store = createRegistryStore({
+    ...baseDeps(),
+    fetchFn: pagedFetch([[raw('1', 'eth')], [raw('1', 'eth-dup')]]),
+  })
+  await store.init()
+  const all = store.getAllChains().filter((c) => c.chainId === 1)
+  assert.equal(all.length, 1)
+  assert.equal(all[0].shortName, 'eth')
+})
+
+test('getChain resolves registry value; FALLBACK only fills gaps (registry wins)', async () => {
+  const fallback: Record<number, AppChain> = {
+    1: { chainId: 1, name: 'STALE', shortName: 'stale', nativeAsset: { symbol: 'X', decimals: 18 }, rpc: '', explorer: { name: '', url: '', apiUrl: '' }, verifyContractUrl: '', safeTransactionApi: null, safeUrl: '', features: [] },
+    999: { chainId: 999, name: 'Hemi-like', shortName: 'hemi', nativeAsset: { symbol: 'ETH', decimals: 18 }, rpc: 'https://rpc.hemi', explorer: { name: 'H', url: 'https://h', apiUrl: 'https://h/api' }, verifyContractUrl: 'https://h/verifyContract', safeTransactionApi: null, safeUrl: '', features: [] },
+  }
+  const store = createRegistryStore({ ...baseDeps(), fallback, fetchFn: pagedFetch([[raw('1', 'eth')]]) })
+  await store.init()
+  assert.equal(store.getChain(1)!.name, 'Chain 1') // registry beats fallback
+  assert.equal(store.getChain(999)!.name, 'Hemi-like') // fallback fills the gap
+})
+
+test('on fetch failure, falls back to the localStorage cache and never throws', async () => {
+  const storage = memStorage()
+  // warm the cache via a successful run
+  const ok = createRegistryStore({ ...baseDeps(), storage, fetchFn: pagedFetch([[raw('1', 'eth')]]) })
+  await ok.init()
+  // new boot, registry unreachable
+  const store = createRegistryStore({
+    ...baseDeps(),
+    storage,
+    fetchFn: async () => {
+      throw new Error('network down')
+    },
+  })
+  await assert.doesNotReject(() => store.init())
+  assert.equal(store.getSource(), 'cache')
+  assert.equal(store.getChain(1)!.shortName, 'eth')
+})
+
+test('cold boot, empty cache, registry unreachable resolves only FALLBACK chains', async () => {
+  const fallback: Record<number, AppChain> = {
+    999: { chainId: 999, name: 'Hemi', shortName: 'hemi', nativeAsset: { symbol: 'ETH', decimals: 18 }, rpc: 'https://rpc.hemi', explorer: { name: 'H', url: 'https://h', apiUrl: 'https://h/api' }, verifyContractUrl: 'https://h/verifyContract', safeTransactionApi: null, safeUrl: '', features: [] },
+  }
+  const store = createRegistryStore({
+    ...baseDeps(),
+    fallback,
+    storage: memStorage(),
+    fetchFn: async () => {
+      throw new Error('down')
+    },
+  })
+  await store.init()
+  assert.equal(store.getSource(), 'fallback')
+  assert.deepEqual(store.getAllChains().map((c) => c.chainId), [999])
+})
+
+test('gate narrows getAllChains but getChain still resolves a non-gated chain', async () => {
+  const store = createRegistryStore({
+    ...baseDeps(),
+    fetchFn: pagedFetch([[raw('1', 'eth'), raw('100', 'gno')]]),
+    gate: (id) => id === 1, // only mainnet is usable
+  })
+  await store.init()
+  assert.deepEqual(store.getAllChains().map((c) => c.chainId), [1])
+  assert.equal(store.getChain(100)!.shortName, 'gno') // metadata still resolvable
+})

--- a/packages/exit-app/src/chains/registryStore.ts
+++ b/packages/exit-app/src/chains/registryStore.ts
@@ -1,0 +1,141 @@
+// Registry store: fetches the Chain Registry (paginating via `next`), derives the
+// app chain shape, caches to localStorage, and resolves each chain as
+// `registry[id] ?? cache[id] ?? FALLBACK[id]`. Never throws from init().
+//
+// Implemented as a factory so it can be driven with injected fetch/storage/clock in
+// tests (see registryStore.nodetest.ts); the app wires a browser-backed singleton in
+// registry.ts.
+import { toAppChain } from './deriveChain.ts'
+import type { AppChain, RegistryChainRaw } from './deriveChain.ts'
+
+export type RegistrySource = 'uninitialized' | 'registry' | 'cache' | 'fallback'
+
+export interface RegistryStoreDeps {
+  fetchFn: typeof fetch
+  storage: Storage | undefined
+  now: () => number
+  parentOrigin: string
+  registryUrl: string
+  timeoutMs: number
+  ttlMs: number
+  /** Manual exceptions, keyed by chainId. Backstops chains/fields the registry lacks. */
+  fallback: Record<number, AppChain>
+  /** Whether an (existing) chain is usable/offered. Defaults to always-true. */
+  gate?: (chainId: number) => boolean
+  storageKey?: string
+}
+
+interface CachePayload {
+  fetchedAt: number
+  chains: AppChain[]
+}
+
+interface RegistryPage {
+  results?: RegistryChainRaw[]
+  next?: string | null
+}
+
+const indexByChainId = (chains: AppChain[]): Map<number, AppChain> => {
+  const map = new Map<number, AppChain>()
+  for (const chain of chains) {
+    if (!map.has(chain.chainId)) map.set(chain.chainId, chain) // first occurrence wins
+  }
+  return map
+}
+
+export interface RegistryStore {
+  init(): Promise<void>
+  getChain(chainId: number): AppChain | undefined
+  getAllChains(): AppChain[]
+  getSource(): RegistrySource
+}
+
+export const createRegistryStore = (deps: RegistryStoreDeps): RegistryStore => {
+  const storageKey = deps.storageKey ?? 'zodiac.chainRegistry'
+  const gate = deps.gate ?? (() => true)
+
+  let registryMap = new Map<number, AppChain>()
+  let cacheMap = new Map<number, AppChain>()
+  let source: RegistrySource = 'uninitialized'
+
+  const readCache = (): AppChain[] | undefined => {
+    try {
+      const raw = deps.storage?.getItem(storageKey)
+      if (!raw) return undefined
+      const payload = JSON.parse(raw) as CachePayload
+      return Array.isArray(payload.chains) ? payload.chains : undefined
+    } catch {
+      return undefined
+    }
+  }
+
+  const writeCache = (chains: AppChain[]): void => {
+    try {
+      const payload: CachePayload = { fetchedAt: deps.now(), chains }
+      deps.storage?.setItem(storageKey, JSON.stringify(payload))
+    } catch {
+      // storage may be full or unavailable — caching is best-effort.
+    }
+  }
+
+  const fetchAllPages = async (): Promise<RegistryChainRaw[]> => {
+    const controller = new AbortController()
+    const timer = setTimeout(() => controller.abort(), deps.timeoutMs)
+    try {
+      const all: RegistryChainRaw[] = []
+      let url: string | null = deps.registryUrl
+      let guard = 0
+      while (url && guard++ < 100) {
+        const response: Response = await deps.fetchFn(url, { signal: controller.signal })
+        if (!response.ok) throw new Error(`registry responded ${response.status}`)
+        const page = (await response.json()) as RegistryPage
+        if (page.results) all.push(...page.results)
+        url = page.next ?? null
+      }
+      return all
+    } finally {
+      clearTimeout(timer)
+    }
+  }
+
+  const init = async (): Promise<void> => {
+    // Seed from cache first so a slow/failed fetch still has warm data.
+    const cached = readCache()
+    if (cached) cacheMap = indexByChainId(cached)
+
+    try {
+      const rawChains = await fetchAllPages()
+      const derived = rawChains
+        .map((raw) => toAppChain(raw, { parentOrigin: deps.parentOrigin }))
+        .filter((chain): chain is AppChain => chain !== null)
+
+      if (derived.length === 0) throw new Error('registry returned no usable chains')
+
+      registryMap = indexByChainId(derived)
+      writeCache(Array.from(registryMap.values()))
+      source = 'registry'
+    } catch {
+      source = cacheMap.size > 0 ? 'cache' : 'fallback'
+    }
+  }
+
+  const getChain = (chainId: number): AppChain | undefined =>
+    registryMap.get(chainId) ?? cacheMap.get(chainId) ?? deps.fallback[chainId]
+
+  const getAllChains = (): AppChain[] => {
+    const ids = new Set<number>([
+      ...registryMap.keys(),
+      ...cacheMap.keys(),
+      ...Object.keys(deps.fallback).map(Number),
+    ])
+    const chains: AppChain[] = []
+    for (const id of ids) {
+      if (!gate(id)) continue
+      const chain = getChain(id)
+      if (chain) chains.push(chain)
+    }
+    return chains
+  }
+
+  return { init, getChain, getAllChains, getSource: () => source }
+}

--- a/packages/exit-app/src/components/AttachAccount/AttachAccount.tsx
+++ b/packages/exit-app/src/components/AttachAccount/AttachAccount.tsx
@@ -13,7 +13,7 @@ import { getAddress, getEIP3770Prefix } from '../../utils/address'
 import { getChainId } from '../../store/main/selectors'
 import { useLocation, useNavigate } from 'react-router-dom'
 import { NOT_A_SAFE_ERROR } from '../Dashboard/Dashboard'
-import { NETWORK_NAME } from '../../utils/networks'
+import { getNetworkName } from '../../utils/networks'
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -120,7 +120,7 @@ export const AttachAccount = () => {
 
         {invalidSafe ? (
           <Typography align="center" color="error" className={classes.errorSpacing}>
-            The account address entered is not a Safe on {NETWORK_NAME[chainId]}. Please confirm it's correct, or use
+            The account address entered is not a Safe on {getNetworkName(chainId)}. Please confirm it's correct, or use
             the dropdown above to attach a Safe deployed on a different network.
           </Typography>
         ) : null}

--- a/packages/exit-app/src/components/ExitCard/ExitButton.tsx
+++ b/packages/exit-app/src/components/ExitCard/ExitButton.tsx
@@ -105,7 +105,7 @@ export const ExitButton = ({ onExit }: ExitButtonProps) => {
     try {
       const checkNetwork = await checkWalletNetwork(network)
       if (!checkNetwork) {
-        const networkName = getNetworkName(network)
+        const networkName = getNetworkName(network) || 'the required network'
         dispatch(setExitStep(EXIT_STEP.ERROR))
         setError('Change current network to ' + networkName)
         return

--- a/packages/exit-app/src/components/Header/Header.tsx
+++ b/packages/exit-app/src/components/Header/Header.tsx
@@ -9,7 +9,7 @@ import { getAccount, getChainId, getENS, getWalletAddress } from '../../store/ma
 import { EthHashInfo } from '@gnosis.pm/safe-react-components'
 import { shortAddress } from '../../utils/strings'
 import { setChainId } from '../../store/main'
-import { NETWORK_NAME } from '../../utils/networks'
+import { getSupportedNetworks } from '../../utils/networks'
 import { colors } from 'zodiac-ui-components'
 
 const useStyles = makeStyles((theme) => ({
@@ -156,9 +156,9 @@ export const Header = () => {
           value={chainId}
           onChange={(evt) => handleNetworkChange(evt.target.value as string)}
         >
-          {Object.entries(NETWORK_NAME).map((pair) => (
-            <MenuItem key={pair[0]} value={pair[0]}>
-              {pair[1]}
+          {getSupportedNetworks().map((network) => (
+            <MenuItem key={network.chainId} value={network.chainId}>
+              {network.name}
             </MenuItem>
           ))}
         </Select>

--- a/packages/exit-app/src/hooks/useWallet.tsx
+++ b/packages/exit-app/src/hooks/useWallet.tsx
@@ -100,7 +100,11 @@ export const useWallet = () => {
   }
 
   useEffect(() => {
+    // RPC now comes from the registry and may be absent for a chain it doesn't carry;
+    // skip building a read provider rather than passing undefined (which silently
+    // defaults to localhost). The injected Safe provider still serves reads/writes.
     const rpcUrl = getNetworkRPC(chainId)
+    if (!rpcUrl) return
     const provider = new ethers.providers.StaticJsonRpcProvider(rpcUrl, chainId)
     setProvider(provider)
   }, [chainId])

--- a/packages/exit-app/src/index.tsx
+++ b/packages/exit-app/src/index.tsx
@@ -7,6 +7,7 @@ import { theme as gnosisStyledComponentsTheme } from '@gnosis.pm/safe-react-comp
 import { App } from './App'
 import { Provider as ReduxProvider } from 'react-redux'
 import { REDUX_STORE } from './store'
+import { initRegistry } from './chains/registry'
 
 const Main = () => {
   return (
@@ -21,9 +22,13 @@ const Main = () => {
   )
 }
 
-ReactDOM.render(
-  <React.StrictMode>
-    <Main />
-  </React.StrictMode>,
-  document.getElementById('root'),
-)
+// Seed chain metadata before first render. initRegistry never throws (falls back to
+// cache/FALLBACK), so render unconditionally via .finally().
+initRegistry().finally(() => {
+  ReactDOM.render(
+    <React.StrictMode>
+      <Main />
+    </React.StrictMode>,
+    document.getElementById('root'),
+  )
+})

--- a/packages/exit-app/src/store/main/actions.ts
+++ b/packages/exit-app/src/store/main/actions.ts
@@ -81,7 +81,10 @@ export const getAvailableTokens = createAsyncThunk(
     token: string
     network: NETWORK
   }): Promise<AvailableToken[]> => {
+    // RPC is registry-sourced and may be absent; without it we cannot read balances —
+    // return no tokens rather than passing undefined (which defaults to localhost).
     const rpcUrl = getNetworkRPC(network)
+    if (!rpcUrl) return []
     const provider = new ethers.providers.StaticJsonRpcProvider(rpcUrl, network)
 
     const ERC721_contract = Erc721__factory.connect(token, provider as any)

--- a/packages/exit-app/src/store/main/index.ts
+++ b/packages/exit-app/src/store/main/index.ts
@@ -2,13 +2,14 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 import { EXIT_STEP, MainState, Token } from './models'
 import { fetchExitModuleData, fetchTokenAssets, getAvailableTokens, getGasEstimationsForAssets } from './actions'
 import { BigNumber, ethers } from 'ethers'
-import { getNetworkName, NETWORK } from '../../utils/networks'
+import { NETWORK } from '../../utils/networks'
 
 const ethereum = (window as any).ethereum
 let initialChainId
 try {
   const chainId: BigNumber | undefined = ethereum && ethereum.chainId && ethers.BigNumber.from(ethereum.chainId)
-  if (chainId && getNetworkName(chainId.toNumber())) {
+  // No gate: adopt whatever chain the wallet reports. If the registry carries it, it works.
+  if (chainId) {
     initialChainId = chainId.toNumber()
   }
 } catch (err) {}

--- a/packages/exit-app/src/utils/explorers.ts
+++ b/packages/exit-app/src/utils/explorers.ts
@@ -1,153 +1,20 @@
-import { NETWORK } from './networks'
+import { getRegistryChain } from '../chains/registry'
 
-const REACT_APP_ETHERSCAN_KEY = process.env.REACT_APP_ETHERSCAN_KEY
-const REACT_APP_OPTIMISTIC_ETHERSCAN_KEY = process.env.REACT_APP_OPTIMISTIC_ETHERSCAN_KEY
-const REACT_APP_ARBISCAN_KEY = process.env.REACT_APP_ARBISCAN_KEY
-const REACT_APP_SNOWTRACE_KEY = process.env.REACT_APP_SNOWTRACE_KEY
-
-// Most of the fields are optional since they are not used in the codebase
-interface ExplorerData {
-  networkExplorerName?: string
-  networkExplorerUrl?: string
-  networkExplorerApiUrl: string
-  safeTransactionApi?: string
-  safeUrl?: string
-  explorerApiKey?: string
-  verifyContractUrl?: string
-}
-
-export const EXPLORERS_CONFIG: Record<NETWORK, ExplorerData> = {
-  [NETWORK.MAINNET]: {
-    networkExplorerName: 'Etherscan',
-    networkExplorerUrl: 'https://etherscan.io',
-    networkExplorerApiUrl: 'https://api.etherscan.io/api',
-    safeTransactionApi: 'https://safe-transaction.gnosis.io/',
-    safeUrl: 'https://gnosis-safe.io/app/eth:',
-    verifyContractUrl: 'https://etherscan.io/verifyContract',
-    explorerApiKey: REACT_APP_ETHERSCAN_KEY,
-  },
-  [NETWORK.SEPOLIA]: {
-    networkExplorerName: 'Etherscan',
-    networkExplorerUrl: 'https://sepolia.etherscan.io',
-    networkExplorerApiUrl: 'https://api-sepolia.etherscan.io/api',
-    safeTransactionApi: 'https://safe-transaction.sepolia.gnosis.io/',
-    safeUrl: 'https://gnosis-safe.io/app/sep:',
-    verifyContractUrl: 'https://sepolia.etherscan.io/verifyContract',
-    explorerApiKey: REACT_APP_ETHERSCAN_KEY,
-  },
-  [NETWORK.XDAI]: {
-    networkExplorerName: 'Blockscout',
-    networkExplorerUrl: 'https://blockscout.com/poa/xdai',
-    networkExplorerApiUrl: 'https://blockscout.com/xdai/mainnet/api',
-    safeUrl: 'https://gnosis-safe.io/app/gno:',
-    safeTransactionApi: 'https://safe-transaction.xdai.gnosis.io/',
-    verifyContractUrl: 'https://docs.blockscout.com/for-users/smart-contract-interaction/verifying-a-smart-contract',
-  },
-  [NETWORK.POLYGON]: {
-    networkExplorerName: 'Polygonscan',
-    networkExplorerUrl: 'https://polygonscan.com',
-    networkExplorerApiUrl: 'https://api.polygonscan.com/api',
-    safeUrl: 'https://gnosis-safe.io/app/matic:',
-    safeTransactionApi: 'https://safe-transaction.polygon.gnosis.io/',
-    verifyContractUrl: 'https://polygonscan.com/verifyContract',
-    explorerApiKey: REACT_APP_ETHERSCAN_KEY,
-  },
-  [NETWORK.BSC]: {
-    networkExplorerName: 'Bscscan',
-    networkExplorerUrl: 'https://bscscan.com/',
-    networkExplorerApiUrl: 'https://bscscan.com/api',
-    safeUrl: 'https://gnosis-safe.io/app/bsc:',
-    safeTransactionApi: 'https://safe-transaction.bsc.gnosis.io/',
-    verifyContractUrl: 'https://bscscan.com/verifyContract',
-    explorerApiKey: REACT_APP_ETHERSCAN_KEY,
-  },
-  [NETWORK.OPTIMISM]: {
-    networkExplorerName: 'Etherscan',
-    networkExplorerUrl: 'https://optimistic.etherscan.io/',
-    networkExplorerApiUrl: 'https://api-optimistic.etherscan.io/api',
-    safeTransactionApi: 'https://safe-transaction-optimism.safe.global/',
-    safeUrl: 'https://app.safe.global/home?safe=oeth:',
-    verifyContractUrl: 'https://optimistic.etherscan.io/verifyContract',
-    explorerApiKey: REACT_APP_OPTIMISTIC_ETHERSCAN_KEY,
-  },
-  [NETWORK.ARBITRUMONE]: {
-    networkExplorerName: 'Arbiscan',
-    networkExplorerUrl: 'https://arbiscan.io/',
-    networkExplorerApiUrl: 'https://api.arbiscan.io/api',
-    safeTransactionApi: 'https://safe-transaction-arbitrum.safe.global/',
-    safeUrl: 'https://app.safe.global/home?safe=arb1:',
-    verifyContractUrl: 'https://arbiscan.io/verifyContract',
-    explorerApiKey: REACT_APP_ARBISCAN_KEY,
-  },
-  [NETWORK.AVALANCHE]: {
-    networkExplorerName: 'Snowtrace',
-    networkExplorerUrl: 'https://snowtrace.io/',
-    networkExplorerApiUrl: 'https://api.snowtrace.io/api',
-    safeTransactionApi: 'https://safe-transaction-arbitrum.safe.global/',
-    safeUrl: 'https://app.safe.global/home?safe=avax:',
-    verifyContractUrl: 'https://snowtrace.io/verifyContract',
-    explorerApiKey: REACT_APP_SNOWTRACE_KEY,
-  },
-  [NETWORK.MOONBEAM]: {
-    networkExplorerApiUrl: 'https://api.etherscan.io/v2/api',
-    explorerApiKey: REACT_APP_ETHERSCAN_KEY,
-  },
-  [NETWORK.MOONRIVER]: {
-    networkExplorerApiUrl: 'https://api.etherscan.io/v2/api',
-    explorerApiKey: REACT_APP_ETHERSCAN_KEY,
-  },
-  [NETWORK.MOONBASE]: {
-    networkExplorerApiUrl: 'https://api.etherscan.io/v2/api',
-    explorerApiKey: REACT_APP_ETHERSCAN_KEY,
-  },
-  [NETWORK.LINEA]: {
-    networkExplorerApiUrl: 'https://api.etherscan.io/v2/api',
-    explorerApiKey: REACT_APP_ETHERSCAN_KEY,
-  },
-  [NETWORK.LINEA_SEPOLIA]: {
-    networkExplorerApiUrl: 'https://api.etherscan.io/v2/api',
-    explorerApiKey: REACT_APP_ETHERSCAN_KEY,
-  },
-  [NETWORK.PLASMA]: {
-    networkExplorerApiUrl: "https://api.routescan.io/v2/network/mainnet/evm/9745/etherscan/api",
-  },
-  [NETWORK.PLASMA_TESTNET]: {
-    networkExplorerApiUrl: "https://api.routescan.io/v2/network/testnet/evm/9746_5/etherscan/api",
-  },
-  [NETWORK.ZETACHAIN]: {
-    networkExplorerApiUrl: "https://zetascan.com/api",
-  },
-  [NETWORK.ZETACHAIN_TESTNET]: {
-    networkExplorerApiUrl: "https://testnet.zetascan.com/api",
-  },
-  [NETWORK.FLOW_EVM_MAINNET]: {
-    networkExplorerApiUrl: "https://evm.flowscan.io/api",
-  },
-  [NETWORK.FLOW_EVM_TESTNET]: {
-    networkExplorerApiUrl: "https://evm-testnet.flowscan.io/api",
-  },
-  [NETWORK.BERACHAIN]: {
-    networkExplorerApiUrl: "https://api.etherscan.io/v2/api",
-    explorerApiKey: REACT_APP_ETHERSCAN_KEY,
-  },
-  [NETWORK.SHAPE]: {
-    networkExplorerApiUrl: 'https://shapescan.xyz/api',
-  },
-  [NETWORK.SHAPE_SEPOLIA]: {
-    networkExplorerApiUrl: 'https://sepolia.shapescan.xyz/api',
-  },
-}
+// Explorer metadata is sourced from the Chain Registry (via getRegistryChain). This app
+// reads balances/transactions through the Client Gateway, so this accessor is EXPLORER
+// ONLY — it intentionally does NOT surface a registry transactionService. The explorer
+// API key is the shared Etherscan V2 key (exit divergence).
+const REACT_APP_ETHERSCAN_V2_KEY = process.env.REACT_APP_ETHERSCAN_V2_KEY
 
 export const getNetworkExplorerInfo = (chainId: number) => {
-  const networkBaseConfig = EXPLORERS_CONFIG[chainId as NETWORK]
-  if (!networkBaseConfig) return
+  const chain = getRegistryChain(chainId)
+  if (!chain) return
   return {
-    name: networkBaseConfig.networkExplorerName,
-    url: networkBaseConfig.networkExplorerUrl,
-    apiUrl: networkBaseConfig.networkExplorerApiUrl,
-    apiKey: networkBaseConfig.explorerApiKey,
-    safeTransactionApi: networkBaseConfig.safeTransactionApi,
-    safeUrl: networkBaseConfig.safeUrl,
-    verifyUrl: networkBaseConfig.verifyContractUrl,
+    name: chain.explorer.name,
+    url: chain.explorer.url,
+    apiUrl: chain.explorer.apiUrl,
+    apiKey: REACT_APP_ETHERSCAN_V2_KEY,
+    safeUrl: chain.safeUrl,
+    verifyUrl: chain.verifyContractUrl,
   }
 }

--- a/packages/exit-app/src/utils/networks.ts
+++ b/packages/exit-app/src/utils/networks.ts
@@ -1,3 +1,5 @@
+import { getAllRegistryChains, getRegistryChain } from '../chains/registry'
+
 const IS_PRODUCTION = process.env.NODE_ENV === 'production'
 
 export enum NETWORK {
@@ -23,56 +25,6 @@ export enum NETWORK {
   BERACHAIN = 80094,
   SHAPE = 360,
   SHAPE_SEPOLIA = 11011,
-}
-
-export const NETWORK_NAME: Record<NETWORK, string> = {
-  [NETWORK.MAINNET]: 'Mainnet',
-  [NETWORK.SEPOLIA]: 'Sepolia',
-  [NETWORK.BSC]: 'Binance Smart Chain',
-  [NETWORK.XDAI]: 'Gnosis Chain',
-  [NETWORK.POLYGON]: 'Polygon',
-  [NETWORK.OPTIMISM]: 'Optimism',
-  [NETWORK.ARBITRUMONE]: 'Arbitrum One',
-  [NETWORK.AVALANCHE]: 'Avalanche',
-  [NETWORK.MOONBEAM]: 'Moonbeam',
-  [NETWORK.MOONRIVER]: 'Moonriver',
-  [NETWORK.MOONBASE]: 'Moonbase',
-  [NETWORK.LINEA]: 'Linea',
-  [NETWORK.LINEA_SEPOLIA]: 'Linea Sepolia',
-  [NETWORK.PLASMA]: 'Plasma',
-  [NETWORK.PLASMA_TESTNET]: 'Plasma Testnet',
-  [NETWORK.ZETACHAIN]: 'ZetaChain',
-  [NETWORK.ZETACHAIN_TESTNET]: 'ZetaChain Testnet',
-  [NETWORK.FLOW_EVM_MAINNET]: 'Flow EVM Mainnet',
-  [NETWORK.FLOW_EVM_TESTNET]: 'Flow EVM Testnet',
-  [NETWORK.BERACHAIN]: 'Berachain',
-  [NETWORK.SHAPE]: 'Shape',
-  [NETWORK.SHAPE_SEPOLIA]: 'Shape Sepolia Testnet',
-}
-
-export const NETWORK_DEFAULT_RPC: Record<NETWORK, string> = {
-  [NETWORK.MAINNET]: 'https://eth.llamarpc.com',
-  [NETWORK.SEPOLIA]: 'https://ethereum-sepolia-rpc.publicnode.com',
-  [NETWORK.BSC]: 'https://bsc-rpc.publicnode.com', 
-  [NETWORK.XDAI]: 'https://gnosis.publicnode.com', 
-  [NETWORK.POLYGON]: 'https://polygon-rpc.com',
-  [NETWORK.OPTIMISM]: 'https://mainnet.optimism.io',
-  [NETWORK.ARBITRUMONE]: 'https://arb1.arbitrum.io/rpc',
-  [NETWORK.AVALANCHE]: 'https://avalanche.publicnode.com',
-  [NETWORK.MOONBEAM]: 'https://rpc.api.moonbeam.network',
-  [NETWORK.MOONRIVER]: 'https://rpc.api.moonriver.moonbeam.network',
-  [NETWORK.MOONBASE]: 'https://rpc.api.moonbase.moonbeam.network',
-  [NETWORK.LINEA]: `https://rpc.linea.build`,
-  [NETWORK.LINEA_SEPOLIA]: `https://rpc.sepolia.linea.build`,
-  [NETWORK.PLASMA]: 'https://rpc.plasma.to',
-  [NETWORK.PLASMA_TESTNET]: 'https://testnet-rpc.plasma.to',
-  [NETWORK.ZETACHAIN]: 'https://zetachain-mainnet.g.allthatnode.com/archive/evm',
-  [NETWORK.ZETACHAIN_TESTNET]: 'https://zetachain-athens.g.allthatnode.com/archive/evm',
-  [NETWORK.FLOW_EVM_MAINNET]: 'https://mainnet.evm.nodes.onflow.org',
-  [NETWORK.FLOW_EVM_TESTNET]: 'https://testnet.evm.nodes.onflow.org',
-  [NETWORK.BERACHAIN]: 'https://rpc.berachain.com',
-  [NETWORK.SHAPE]: 'https://mainnet.shape.network',
-  [NETWORK.SHAPE_SEPOLIA]: 'https://sepolia.shape.network',
 }
 
 export const NETWORK_CGW_BASE_URI: Partial<Record<NETWORK, string>> = {
@@ -112,11 +64,20 @@ export const CUSTOM_MULTICALL_ADDRESSES: Partial<Record<NETWORK, string>> = {
 }
 
 export function getNetworkRPC(network: NETWORK) {
-  return NETWORK_DEFAULT_RPC[network]
+  return getRegistryChain(network)?.rpc
 }
 
 export function getNetworkName(network: NETWORK) {
-  return NETWORK_NAME[network]
+  return getRegistryChain(network)?.name
+}
+
+/**
+ * The networks to offer in pickers (Header dropdown, AttachAccount). Replaces the
+ * iterated NETWORK_NAME map: sourced from the registry, already gated to the supported
+ * NETWORK enum ids by the registry store.
+ */
+export function getSupportedNetworks(): { chainId: number; name: string }[] {
+  return getAllRegistryChains().map((chain) => ({ chainId: chain.chainId, name: chain.name }))
 }
 
 /* comment out unused code


### PR DESCRIPTION
## Summary
Drive chain **metadata** from the Chain Registry (`registry.safe.protofire.io/api/v1/chains/`) at runtime instead of hand-maintained per-chain tables. Resolution per chain: `registry[id] ?? cache[id] ?? FALLBACK[id]`. Loader paginates (follows `next`), caches to localStorage, merges a small committed FALLBACK (Hemi/Katana/Lens/Peaq), and never throws on boot.

Rewrote \`getNetworkExplorerInfo\` (explorer-only) + \`getNetworkName\`/\`getNetworkRPC\` from the registry; the network dropdown now shows all registry chains (**no gate**). The Client Gateway (\`safeTransactionApi.ts\` + \`NETWORK_CGW_BASE_URI\`) and \`CUSTOM_MULTICALL_ADDRESSES\` are left untouched (option B). Provider call sites guarded against a missing RPC.

## Tests
Shared core (`src/chains/`) covered by 15 `node:test` cases — run `yarn test:chains`.

## Not done in this environment
Full `yarn build` was **not** run (repo pins Node 16 + react-scripts; deps not installed). Pure core is tested; cutover edits verified by review + grep. **Run `yarn build` on Node 16 before merge.**